### PR TITLE
Rename `WorkspaceClientCapabilities::diagnostic` to the name matching…

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1360,7 +1360,7 @@ pub struct WorkspaceClientCapabilities {
     /// Client workspace capabilities specific to diagnostics.
     /// since 3.17.0
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub diagnostic: Option<DiagnosticWorkspaceClientCapabilities>,
+    pub diagnostics: Option<DiagnosticWorkspaceClientCapabilities>,
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]


### PR DESCRIPTION
… the specification, `WorkspaceClientCapabilities::diagnostics`